### PR TITLE
fix: normalize local custom reaction deletion

### DIFF
--- a/packages/backend/src/core/ReactionService.ts
+++ b/packages/backend/src/core/ReactionService.ts
@@ -299,7 +299,7 @@ export class ReactionService {
 			exist = await this.noteReactionsRepository.findOneBy({
 				noteId: note.id,
 				userId: user.id,
-				reaction: reaction.replace(/@\.$/, ''),
+				reaction: this.toDbReaction(reaction),
 			});
 		}
 
@@ -387,6 +387,16 @@ export class ReactionService {
 
 				return acc;
 			}, {});
+	}
+
+	@bindThis
+	public toDbReaction(reaction: string): string {
+		const custom = reaction.match(decodeCustomEmojiRegexp);
+		if (custom?.[2] === '.') {
+			return `:${custom[1]}:`;
+		}
+
+		return reaction;
 	}
 
 	@bindThis

--- a/packages/backend/test/unit/ReactionService.ts
+++ b/packages/backend/test/unit/ReactionService.ts
@@ -91,6 +91,20 @@ describe('ReactionService', () => {
 		});
 	});
 
+	describe('toDbReaction', () => {
+		test('ローカルカスタム絵文字の @. を DB 形式に戻す', () => {
+			assert.strictEqual(reactionService.toDbReaction(':custom_emoji@.:'), ':custom_emoji:');
+		});
+
+		test('リモートカスタム絵文字はそのまま保持する', () => {
+			assert.strictEqual(reactionService.toDbReaction(':custom_emoji@example.com:'), ':custom_emoji@example.com:');
+		});
+
+		test('Unicode 絵文字はそのまま保持する', () => {
+			assert.strictEqual(reactionService.toDbReaction('👍'), '👍');
+		});
+	});
+
 	describe('convertLegacyReactions', () => {
 		test('空の入力に対しては何もしない', () => {
 			const input = {};


### PR DESCRIPTION
## Summary
- fix `notes/reactions/delete` so local custom emoji reactions like `:name@.:` are converted back to the DB format before lookup
- add unit coverage for local custom emoji, remote custom emoji, and unicode reaction normalization in the delete path
- this resolves `NOT_REACTED` when removing an existing local custom emoji reaction from a note

## Verification
- inspected the reaction create/delete flow and confirmed the mismatch was in backend normalization before delete lookup
- ran `pnpm --filter backend test -- --runInBand ReactionService` (fails in this environment because PostgreSQL on `5432` and Redis on `6379` are not available)