### PR TITLE
Enhance: ActivityPub連合処理の負荷集中を抑制

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Server
 - Enhance: Docker・systemd の起動時に pnpm を常駐させないようにしてメモリ使用量を削減
 - Enhance: リモートノートクリーニングジョブのスキップ処理のパフォーマンス改善
+- Enhance: ActivityPub の featured 応答・JSON-LD エラー処理・フェデレーション集計の負荷を軽減
 
 
 ## 2026.5.4

--- a/packages/backend/src/core/CoreModule.ts
+++ b/packages/backend/src/core/CoreModule.ts
@@ -61,6 +61,7 @@ import { SignupService } from './SignupService.js';
 import { WebAuthnService } from './WebAuthnService.js';
 import { UserBlockingService } from './UserBlockingService.js';
 import { CacheService } from './CacheService.js';
+import { FeaturedCollectionCacheService } from './FeaturedCollectionCacheService.js';
 import { UserService } from './UserService.js';
 import { UserFollowingService } from './UserFollowingService.js';
 import { UserKeypairService } from './UserKeypairService.js';
@@ -215,6 +216,7 @@ const $SignupService: Provider = { provide: 'SignupService', useExisting: Signup
 const $WebAuthnService: Provider = { provide: 'WebAuthnService', useExisting: WebAuthnService };
 const $UserBlockingService: Provider = { provide: 'UserBlockingService', useExisting: UserBlockingService };
 const $CacheService: Provider = { provide: 'CacheService', useExisting: CacheService };
+const $FeaturedCollectionCacheService: Provider = { provide: 'FeaturedCollectionCacheService', useExisting: FeaturedCollectionCacheService };
 const $UserService: Provider = { provide: 'UserService', useExisting: UserService };
 const $UserFollowingService: Provider = { provide: 'UserFollowingService', useExisting: UserFollowingService };
 const $UserKeypairService: Provider = { provide: 'UserKeypairService', useExisting: UserKeypairService };
@@ -377,6 +379,7 @@ const $ApQuestionService: Provider = { provide: 'ApQuestionService', useExisting
 		WebAuthnService,
 		UserBlockingService,
 		CacheService,
+		FeaturedCollectionCacheService,
 		UserService,
 		UserFollowingService,
 		UserKeypairService,
@@ -535,6 +538,7 @@ const $ApQuestionService: Provider = { provide: 'ApQuestionService', useExisting
 		$WebAuthnService,
 		$UserBlockingService,
 		$CacheService,
+		$FeaturedCollectionCacheService,
 		$UserService,
 		$UserFollowingService,
 		$UserKeypairService,
@@ -695,6 +699,7 @@ const $ApQuestionService: Provider = { provide: 'ApQuestionService', useExisting
 		WebAuthnService,
 		UserBlockingService,
 		CacheService,
+		FeaturedCollectionCacheService,
 		UserService,
 		UserFollowingService,
 		UserKeypairService,

--- a/packages/backend/src/core/FeaturedCollectionCacheService.ts
+++ b/packages/backend/src/core/FeaturedCollectionCacheService.ts
@@ -9,10 +9,11 @@ import * as Redis from 'ioredis';
 import { DI } from '@/di-symbols.js';
 import type { IOrderedCollection } from '@/core/activitypub/type.js';
 
-const FEATURED_COLLECTION_CACHE_TTL_SECONDS = 180;
+export const FEATURED_COLLECTION_CACHE_TTL_SECONDS = 180;
 const FEATURED_COLLECTION_VERSION_TTL_SECONDS = 24 * 60 * 60;
 const FEATURED_COLLECTION_LOCK_TTL_MS = 30_000;
 const FEATURED_COLLECTION_LOCK_POLL_INTERVAL_MS = 100;
+const FEATURED_COLLECTION_LOCK_WAIT_TIMEOUT_MS = 5_000;
 
 export type FeaturedCollection = IOrderedCollection & {
 	'@context': unknown;
@@ -91,7 +92,7 @@ export class FeaturedCollectionCacheService {
 		// Another worker is rendering this user. Poll the shared cache instead of
 		// rendering the same collection again. A bounded fallback preserves
 		// availability if the lock holder crashed or Redis lost the lock state.
-		const deadline = Date.now() + FEATURED_COLLECTION_LOCK_TTL_MS;
+		const deadline = Date.now() + FEATURED_COLLECTION_LOCK_WAIT_TIMEOUT_MS;
 		while (Date.now() < deadline) {
 			await new Promise<void>(resolve => setTimeout(resolve, FEATURED_COLLECTION_LOCK_POLL_INTERVAL_MS));
 			const cached = await this.get(userId);
@@ -221,15 +222,17 @@ export class FeaturedCollectionCacheService {
 		this.inFlight.delete(userId);
 
 		try {
-			// Incrementing the version and deleting the value in one Redis script
-			// closes the race with a render running in another backend worker.
+			// Replacing the version with a non-repeating token and deleting the
+			// value atomically closes the race with a render running in another
+			// backend worker. A random token remains safe even if the version key
+			// expired between the render and this invalidation.
 			await this.redisClient.eval(
-				`redis.call('incr', KEYS[1])
-				redis.call('expire', KEYS[1], ARGV[1])
+				`redis.call('set', KEYS[1], ARGV[1], 'EX', ARGV[2])
 				return redis.call('del', KEYS[2])`,
 				2,
 				this.versionKey(userId),
 				this.cacheKey(userId),
+				randomUUID(),
 				FEATURED_COLLECTION_VERSION_TTL_SECONDS,
 			);
 		} catch {

--- a/packages/backend/src/core/FeaturedCollectionCacheService.ts
+++ b/packages/backend/src/core/FeaturedCollectionCacheService.ts
@@ -1,0 +1,239 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { randomUUID } from 'node:crypto';
+import { Inject, Injectable } from '@nestjs/common';
+import * as Redis from 'ioredis';
+import { DI } from '@/di-symbols.js';
+import type { IOrderedCollection } from '@/core/activitypub/type.js';
+
+const FEATURED_COLLECTION_CACHE_TTL_SECONDS = 180;
+const FEATURED_COLLECTION_VERSION_TTL_SECONDS = 24 * 60 * 60;
+const FEATURED_COLLECTION_LOCK_TTL_MS = 30_000;
+const FEATURED_COLLECTION_LOCK_POLL_INTERVAL_MS = 100;
+
+export type FeaturedCollection = IOrderedCollection & {
+	'@context': unknown;
+};
+
+type InFlightRender = {
+	promise: Promise<FeaturedCollection>;
+	token: {
+		invalidated: boolean;
+	};
+};
+
+/**
+ * Short-lived cache for the local ActivityPub featured collection.
+ *
+ * The collection is public and the endpoint already advertises a 180 second
+ * cache lifetime. Redis is used as the shared cache so all backend workers can
+ * reuse a rendered collection, while the in-flight map prevents a thundering
+ * herd inside one worker when a key expires.
+ */
+@Injectable()
+export class FeaturedCollectionCacheService {
+	private readonly inFlight = new Map<string, InFlightRender>();
+
+	constructor(
+		@Inject(DI.redis)
+		private redisClient: Redis.Redis,
+	) {
+	}
+
+	private cacheKey(userId: string): string {
+		return `kvcache:activityPubFeatured:${userId}`;
+	}
+
+	private versionKey(userId: string): string {
+		return `${this.cacheKey(userId)}:version`;
+	}
+
+	private lockKey(userId: string): string {
+		return `${this.cacheKey(userId)}:lock`;
+	}
+
+	public async fetch(userId: string, loader: () => Promise<FeaturedCollection>): Promise<FeaturedCollection> {
+		const pending = this.inFlight.get(userId);
+		if (pending != null) return pending.promise;
+
+		const token = { invalidated: false };
+		const promise = this.fetchAndStore(userId, token, loader);
+		const render = { promise, token };
+		this.inFlight.set(userId, render);
+
+		try {
+			return await promise;
+		} finally {
+			if (this.inFlight.get(userId) === render) this.inFlight.delete(userId);
+		}
+	}
+
+	private async fetchAndStore(
+		userId: string,
+		token: InFlightRender['token'],
+		loader: () => Promise<FeaturedCollection>,
+	): Promise<FeaturedCollection> {
+		const cached = await this.get(userId);
+		if (cached != null) return cached;
+
+		const lockToken = randomUUID();
+		const lockState = await this.tryAcquireLock(userId, lockToken);
+		if (lockState === 'acquired') {
+			return this.fetchWithLock(userId, lockToken, token, loader);
+		}
+		if (lockState === 'unavailable') {
+			return this.renderAndStore(userId, token, loader);
+		}
+
+		// Another worker is rendering this user. Poll the shared cache instead of
+		// rendering the same collection again. A bounded fallback preserves
+		// availability if the lock holder crashed or Redis lost the lock state.
+		const deadline = Date.now() + FEATURED_COLLECTION_LOCK_TTL_MS;
+		while (Date.now() < deadline) {
+			await new Promise<void>(resolve => setTimeout(resolve, FEATURED_COLLECTION_LOCK_POLL_INTERVAL_MS));
+			const cached = await this.get(userId);
+			if (cached != null) return cached;
+
+			const nextLockState = await this.tryAcquireLock(userId, lockToken);
+			if (nextLockState === 'acquired') {
+				return this.fetchWithLock(userId, lockToken, token, loader);
+			}
+			if (nextLockState === 'unavailable') {
+				return this.renderAndStore(userId, token, loader);
+			}
+		}
+
+		return this.renderAndStore(userId, token, loader);
+	}
+
+	private async fetchWithLock(
+		userId: string,
+		lockToken: string,
+		token: InFlightRender['token'],
+		loader: () => Promise<FeaturedCollection>,
+	): Promise<FeaturedCollection> {
+		try {
+			// The lock holder may have been queued behind another worker that
+			// populated the value just before this lock was acquired.
+			const cached = await this.get(userId);
+			if (cached != null) return cached;
+			return await this.renderAndStore(userId, token, loader);
+		} finally {
+			await this.releaseLock(userId, lockToken);
+		}
+	}
+
+	private async renderAndStore(
+		userId: string,
+		token: InFlightRender['token'],
+		loader: () => Promise<FeaturedCollection>,
+	): Promise<FeaturedCollection> {
+		const version = await this.getVersion(userId);
+		const value = await loader();
+
+		// A pin update may have happened while rendering. Do not repopulate Redis
+		// with the now-stale result after invalidate() marked this render.
+		if (!token.invalidated) await this.set(userId, version, value);
+
+		return value;
+	}
+
+	private async tryAcquireLock(userId: string, token: string): Promise<'acquired' | 'busy' | 'unavailable'> {
+		try {
+			const result = await this.redisClient.set(
+				this.lockKey(userId),
+				token,
+				'PX', FEATURED_COLLECTION_LOCK_TTL_MS,
+				'NX',
+			);
+			return result === 'OK' ? 'acquired' : 'busy';
+		} catch {
+			return 'unavailable';
+		}
+	}
+
+	private async releaseLock(userId: string, token: string): Promise<void> {
+		try {
+			await this.redisClient.eval(
+				`if redis.call('get', KEYS[1]) == ARGV[1] then
+					return redis.call('del', KEYS[1])
+				end
+				return 0`,
+				1,
+				this.lockKey(userId),
+				token,
+			);
+		} catch {
+			// The lock has a bounded TTL and will expire automatically.
+		}
+	}
+
+	private async get(userId: string): Promise<FeaturedCollection | undefined> {
+		try {
+			const value = await this.redisClient.get(this.cacheKey(userId));
+			return value == null ? undefined : JSON.parse(value) as FeaturedCollection;
+		} catch {
+			// The cache is an optimization. Redis failures must not make AP
+			// responses fail; the caller will render from the database instead.
+			return undefined;
+		}
+	}
+
+	private async getVersion(userId: string): Promise<string> {
+		try {
+			return await this.redisClient.get(this.versionKey(userId)) ?? '0';
+		} catch {
+			return '0';
+		}
+	}
+
+	private async set(userId: string, version: string, value: FeaturedCollection): Promise<void> {
+		try {
+			// Check the invalidation version and write the value atomically. This
+			// prevents another worker's in-flight render from repopulating Redis
+			// after a pin update has invalidated the key.
+			await this.redisClient.eval(
+				`local current = redis.call('get', KEYS[1])
+				if (current == false and ARGV[1] == '0') or current == ARGV[1] then
+					return redis.call('set', KEYS[2], ARGV[2], 'EX', ARGV[3])
+				end
+				return nil`,
+				2,
+				this.versionKey(userId),
+				this.cacheKey(userId),
+				version,
+				JSON.stringify(value),
+				FEATURED_COLLECTION_CACHE_TTL_SECONDS,
+			);
+		} catch {
+			// Best-effort cache only; keep serving the freshly rendered value.
+		}
+	}
+
+	public async invalidate(userId: string): Promise<void> {
+		// Let a new request start a fresh render immediately. The old promise is
+		// still allowed to finish, but its token prevents stale writes.
+		const render = this.inFlight.get(userId);
+		if (render != null) render.token.invalidated = true;
+		this.inFlight.delete(userId);
+
+		try {
+			// Incrementing the version and deleting the value in one Redis script
+			// closes the race with a render running in another backend worker.
+			await this.redisClient.eval(
+				`redis.call('incr', KEYS[1])
+				redis.call('expire', KEYS[1], ARGV[1])
+				return redis.call('del', KEYS[2])`,
+				2,
+				this.versionKey(userId),
+				this.cacheKey(userId),
+				FEATURED_COLLECTION_VERSION_TTL_SECONDS,
+			);
+		} catch {
+			// Best-effort invalidation; TTL remains the safety net.
+		}
+	}
+}

--- a/packages/backend/src/core/NoteDeleteService.ts
+++ b/packages/backend/src/core/NoteDeleteService.ts
@@ -7,7 +7,7 @@ import { Brackets, In, IsNull, Not } from 'typeorm';
 import { Injectable, Inject } from '@nestjs/common';
 import type { MiUser, MiLocalUser, MiRemoteUser } from '@/models/User.js';
 import type { MiNote, IMentionedRemoteUsers } from '@/models/Note.js';
-import type { InstancesRepository, MiMeta, NotesRepository, UsersRepository } from '@/models/_.js';
+import type { InstancesRepository, MiMeta, NotesRepository, UserNotePiningsRepository, UsersRepository } from '@/models/_.js';
 import { RelayService } from '@/core/RelayService.js';
 import { FederatedInstanceService } from '@/core/FederatedInstanceService.js';
 import { DI } from '@/di-symbols.js';
@@ -43,6 +43,9 @@ export class NoteDeleteService {
 		@Inject(DI.instancesRepository)
 		private instancesRepository: InstancesRepository,
 
+		@Inject(DI.userNotePiningsRepository)
+		private userNotePiningsRepository: UserNotePiningsRepository,
+
 		private userEntityService: UserEntityService,
 		private globalEventService: GlobalEventService,
 		private relayService: RelayService,
@@ -64,7 +67,10 @@ export class NoteDeleteService {
 	 */
 	async delete(user: { id: MiUser['id']; uri: MiUser['uri']; host: MiUser['host']; isBot: MiUser['isBot']; }, note: MiNote, quiet = false, deleter?: MiUser) {
 		const deletedAt = new Date();
-		const invalidatesFeaturedCollection = this.userEntityService.isLocalUser(user);
+		const invalidatesFeaturedCollection = this.userEntityService.isLocalUser(user) && await this.userNotePiningsRepository.existsBy({
+			userId: user.id,
+			noteId: note.id,
+		});
 
 		if (note.replyId) {
 			await this.notesRepository.decrement({ id: note.replyId }, 'repliesCount', 1);

--- a/packages/backend/src/core/NoteDeleteService.ts
+++ b/packages/backend/src/core/NoteDeleteService.ts
@@ -7,7 +7,7 @@ import { Brackets, In, IsNull, Not } from 'typeorm';
 import { Injectable, Inject } from '@nestjs/common';
 import type { MiUser, MiLocalUser, MiRemoteUser } from '@/models/User.js';
 import type { MiNote, IMentionedRemoteUsers } from '@/models/Note.js';
-import type { InstancesRepository, MiMeta, NotesRepository, UserNotePiningsRepository, UsersRepository } from '@/models/_.js';
+import type { InstancesRepository, MiMeta, NotesRepository, UsersRepository } from '@/models/_.js';
 import { RelayService } from '@/core/RelayService.js';
 import { FederatedInstanceService } from '@/core/FederatedInstanceService.js';
 import { DI } from '@/di-symbols.js';
@@ -43,9 +43,6 @@ export class NoteDeleteService {
 		@Inject(DI.instancesRepository)
 		private instancesRepository: InstancesRepository,
 
-		@Inject(DI.userNotePiningsRepository)
-		private userNotePiningsRepository: UserNotePiningsRepository,
-
 		private userEntityService: UserEntityService,
 		private globalEventService: GlobalEventService,
 		private relayService: RelayService,
@@ -67,10 +64,7 @@ export class NoteDeleteService {
 	 */
 	async delete(user: { id: MiUser['id']; uri: MiUser['uri']; host: MiUser['host']; isBot: MiUser['isBot']; }, note: MiNote, quiet = false, deleter?: MiUser) {
 		const deletedAt = new Date();
-		const invalidatesFeaturedCollection = this.userEntityService.isLocalUser(user) && await this.userNotePiningsRepository.existsBy({
-			userId: user.id,
-			noteId: note.id,
-		});
+		const invalidatesFeaturedCollection = this.userEntityService.isLocalUser(user);
 
 		if (note.replyId) {
 			await this.notesRepository.decrement({ id: note.replyId }, 'repliesCount', 1);

--- a/packages/backend/src/core/NoteDeleteService.ts
+++ b/packages/backend/src/core/NoteDeleteService.ts
@@ -7,7 +7,7 @@ import { Brackets, In, IsNull, Not } from 'typeorm';
 import { Injectable, Inject } from '@nestjs/common';
 import type { MiUser, MiLocalUser, MiRemoteUser } from '@/models/User.js';
 import type { MiNote, IMentionedRemoteUsers } from '@/models/Note.js';
-import type { InstancesRepository, MiMeta, NotesRepository, UsersRepository } from '@/models/_.js';
+import type { InstancesRepository, MiMeta, NotesRepository, UserNotePiningsRepository, UsersRepository } from '@/models/_.js';
 import { RelayService } from '@/core/RelayService.js';
 import { FederatedInstanceService } from '@/core/FederatedInstanceService.js';
 import { DI } from '@/di-symbols.js';
@@ -22,6 +22,7 @@ import { UserEntityService } from '@/core/entities/UserEntityService.js';
 import { bindThis } from '@/decorators.js';
 import { SearchService } from '@/core/SearchService.js';
 import { ModerationLogService } from '@/core/ModerationLogService.js';
+import { FeaturedCollectionCacheService } from '@/core/FeaturedCollectionCacheService.js';
 import { isQuote, isRenote } from '@/misc/is-renote.js';
 
 @Injectable()
@@ -42,6 +43,9 @@ export class NoteDeleteService {
 		@Inject(DI.instancesRepository)
 		private instancesRepository: InstancesRepository,
 
+		@Inject(DI.userNotePiningsRepository)
+		private userNotePiningsRepository: UserNotePiningsRepository,
+
 		private userEntityService: UserEntityService,
 		private globalEventService: GlobalEventService,
 		private relayService: RelayService,
@@ -53,6 +57,7 @@ export class NoteDeleteService {
 		private notesChart: NotesChart,
 		private perUserNotesChart: PerUserNotesChart,
 		private instanceChart: InstanceChart,
+		private featuredCollectionCacheService: FeaturedCollectionCacheService,
 	) {}
 
 	/**
@@ -62,6 +67,10 @@ export class NoteDeleteService {
 	 */
 	async delete(user: { id: MiUser['id']; uri: MiUser['uri']; host: MiUser['host']; isBot: MiUser['isBot']; }, note: MiNote, quiet = false, deleter?: MiUser) {
 		const deletedAt = new Date();
+		const invalidatesFeaturedCollection = this.userEntityService.isLocalUser(user) && await this.userNotePiningsRepository.existsBy({
+			userId: user.id,
+			noteId: note.id,
+		});
 
 		if (note.replyId) {
 			await this.notesRepository.decrement({ id: note.replyId }, 'repliesCount', 1);
@@ -114,6 +123,10 @@ export class NoteDeleteService {
 			id: note.id,
 			userId: user.id,
 		});
+
+		if (invalidatesFeaturedCollection) {
+			await this.featuredCollectionCacheService.invalidate(user.id);
+		}
 
 		if (deleter && (note.userId !== deleter.id)) {
 			const user = await this.usersRepository.findOneByOrFail({ id: note.userId });

--- a/packages/backend/src/core/NotePiningService.ts
+++ b/packages/backend/src/core/NotePiningService.ts
@@ -18,6 +18,7 @@ import { ApDeliverManagerService } from '@/core/activitypub/ApDeliverManagerServ
 import { ApRendererService } from '@/core/activitypub/ApRendererService.js';
 import { bindThis } from '@/decorators.js';
 import { RoleService } from '@/core/RoleService.js';
+import { FeaturedCollectionCacheService } from '@/core/FeaturedCollectionCacheService.js';
 
 @Injectable()
 export class NotePiningService {
@@ -40,6 +41,7 @@ export class NotePiningService {
 		private relayService: RelayService,
 		private apDeliverManagerService: ApDeliverManagerService,
 		private apRendererService: ApRendererService,
+		private featuredCollectionCacheService: FeaturedCollectionCacheService,
 	) {
 	}
 
@@ -75,6 +77,9 @@ export class NotePiningService {
 			userId: user.id,
 			noteId: note.id,
 		} as MiUserNotePining);
+		if (this.userEntityService.isLocalUser(user)) {
+			await this.featuredCollectionCacheService.invalidate(user.id);
+		}
 
 		// Deliver to remote followers
 		if (this.userEntityService.isLocalUser(user) && !note.localOnly && ['public', 'home'].includes(note.visibility)) {
@@ -99,10 +104,13 @@ export class NotePiningService {
 			throw new IdentifiableError('b302d4cf-c050-400a-bbb3-be208681f40c', 'No such note.');
 		}
 
-		this.userNotePiningsRepository.delete({
+		await this.userNotePiningsRepository.delete({
 			userId: user.id,
 			noteId: note.id,
 		});
+		if (this.userEntityService.isLocalUser(user)) {
+			await this.featuredCollectionCacheService.invalidate(user.id);
+		}
 
 		// Deliver to remote followers
 		if (this.userEntityService.isLocalUser(user) && !note.localOnly && ['public', 'home'].includes(note.visibility)) {

--- a/packages/backend/src/core/NoteUpdateService.ts
+++ b/packages/backend/src/core/NoteUpdateService.ts
@@ -9,7 +9,7 @@ import { Inject, Injectable, OnApplicationShutdown } from '@nestjs/common';
 import { extractCustomEmojisFromMfm } from '@/misc/extract-custom-emojis-from-mfm.js';
 import { extractHashtags } from '@/misc/extract-hashtags.js';
 import { MiNote, IMentionedRemoteUsers } from '@/models/Note.js';
-import type { NotesRepository, DriveFilesRepository, UsersRepository } from '@/models/_.js';
+import type { NotesRepository, DriveFilesRepository, UsersRepository, UserNotePiningsRepository } from '@/models/_.js';
 import type { MiDriveFile } from '@/models/DriveFile.js';
 import type { MiUser, MiLocalUser, MiRemoteUser } from '@/models/User.js';
 import { DI } from '@/di-symbols.js';
@@ -23,6 +23,7 @@ import { UserEntityService } from '@/core/entities/UserEntityService.js';
 import { RelayService } from '@/core/RelayService.js';
 import { In } from 'typeorm';
 import ActiveUsersChart from '@/core/chart/charts/active-users.js';
+import { FeaturedCollectionCacheService } from '@/core/FeaturedCollectionCacheService.js';
 import util from 'util';
 
 export type NoteUpdateData = {
@@ -49,6 +50,9 @@ export class NoteUpdateService implements OnApplicationShutdown {
 		@Inject(DI.driveFilesRepository)
 		private driveFilesRepository: DriveFilesRepository,
 
+		@Inject(DI.userNotePiningsRepository)
+		private userNotePiningsRepository: UserNotePiningsRepository,
+
 		private globalEventService: GlobalEventService,
 		private searchService: SearchService,
 		private apRendererService: ApRendererService,
@@ -56,6 +60,7 @@ export class NoteUpdateService implements OnApplicationShutdown {
 		private userEntityService: UserEntityService,
 		private relayService: RelayService,
 		private activeUsersChart: ActiveUsersChart,
+		private featuredCollectionCacheService: FeaturedCollectionCacheService,
 	) {
 	}
 
@@ -128,6 +133,13 @@ export class NoteUpdateService implements OnApplicationShutdown {
 		// Fetch the updated note
 		const updatedNote = await this.notesRepository.findOneByOrFail({ id: note.id });
 
+		if (this.userEntityService.isLocalUser(user) && await this.userNotePiningsRepository.existsBy({
+			userId: user.id,
+			noteId: note.id,
+		})) {
+			await this.featuredCollectionCacheService.invalidate(user.id);
+		}
+
 		if (!silent) {
 			if (this.userEntityService.isLocalUser(user)) this.activeUsersChart.write(user);
 
@@ -141,7 +153,6 @@ export class NoteUpdateService implements OnApplicationShutdown {
 			//#region AP deliver
 			if (this.userEntityService.isLocalUser(user)) {
 				setImmediate(async () => {
-					// @ts-ignore
 					const noteActivity = await this.renderNoteActivity(updatedNote, user);
 					await this.deliverToConcerned(user, updatedNote, noteActivity);
 				});

--- a/packages/backend/src/core/chart/charts/federation.ts
+++ b/packages/backend/src/core/chart/charts/federation.ts
@@ -63,47 +63,52 @@ export default class FederationChart extends Chart<typeof schema> { // eslint-di
 			.select('f.followerHost')
 			.where('f.followerHost IS NOT NULL');
 
-		const [sub, pub, pubsub, subActive, pubActive] = await Promise.all([
-			this.followingsRepository.createQueryBuilder('following')
-				.select('COUNT(DISTINCT following.followeeHost)')
-				.where('following.followeeHost IS NOT NULL')
-				.andWhere(this.meta.blockedHosts.length === 0 ? '1=1' : 'following.followeeHost NOT ILIKE ALL(ARRAY[:...blocked])', { blocked: this.meta.blockedHosts.flatMap(x => [x, `%.${x}`]) })
-				.andWhere(`following.followeeHost NOT IN (${ suspendedInstancesQuery.getQuery() })`)
-				.getRawOne()
-				.then(x => parseInt(x.count, 10)),
-			this.followingsRepository.createQueryBuilder('following')
-				.select('COUNT(DISTINCT following.followerHost)')
-				.where('following.followerHost IS NOT NULL')
-				.andWhere(this.meta.blockedHosts.length === 0 ? '1=1' : 'following.followerHost NOT ILIKE ALL(ARRAY[:...blocked])', { blocked: this.meta.blockedHosts.flatMap(x => [x, `%.${x}`]) })
-				.andWhere(`following.followerHost NOT IN (${ suspendedInstancesQuery.getQuery() })`)
-				.getRawOne()
-				.then(x => parseInt(x.count, 10)),
-			this.followingsRepository.createQueryBuilder('following')
-				.select('COUNT(DISTINCT following.followeeHost)')
-				.where('following.followeeHost IS NOT NULL')
-				.andWhere(this.meta.blockedHosts.length === 0 ? '1=1' : 'following.followeeHost NOT ILIKE ALL(ARRAY[:...blocked])', { blocked: this.meta.blockedHosts.flatMap(x => [x, `%.${x}`]) })
-				.andWhere(`following.followeeHost NOT IN (${ suspendedInstancesQuery.getQuery() })`)
-				.andWhere(`following.followeeHost IN (${ pubsubSubQuery.getQuery() })`)
-				.setParameters(pubsubSubQuery.getParameters())
-				.getRawOne()
-				.then(x => parseInt(x.count, 10)),
-			this.instancesRepository.createQueryBuilder('instance')
-				.select('COUNT(instance.id)')
-				.where(`instance.host IN (${ subInstancesQuery.getQuery() })`)
-				.andWhere(this.meta.blockedHosts.length === 0 ? '1=1' : 'instance.host NOT ILIKE ALL(ARRAY[:...blocked])', { blocked: this.meta.blockedHosts.flatMap(x => [x, `%.${x}`]) })
-				.andWhere('instance.suspensionState = \'none\'')
-				.andWhere('instance.isNotResponding = false')
-				.getRawOne()
-				.then(x => parseInt(x.count, 10)),
-			this.instancesRepository.createQueryBuilder('instance')
-				.select('COUNT(instance.id)')
-				.where(`instance.host IN (${ pubInstancesQuery.getQuery() })`)
-				.andWhere(this.meta.blockedHosts.length === 0 ? '1=1' : 'instance.host NOT ILIKE ALL(ARRAY[:...blocked])', { blocked: this.meta.blockedHosts.flatMap(x => [x, `%.${x}`]) })
-				.andWhere('instance.suspensionState = \'none\'')
-				.andWhere('instance.isNotResponding = false')
-				.getRawOne()
-				.then(x => parseInt(x.count, 10)),
-		]);
+		// These aggregate queries can each be expensive on a large federation
+		// graph. Run them sequentially so the hourly chart tick does not issue
+		// five concurrent scans against PostgreSQL.
+		const sub = await this.followingsRepository.createQueryBuilder('following')
+			.select('COUNT(DISTINCT following.followeeHost)')
+			.where('following.followeeHost IS NOT NULL')
+			.andWhere(this.meta.blockedHosts.length === 0 ? '1=1' : 'following.followeeHost NOT ILIKE ALL(ARRAY[:...blocked])', { blocked: this.meta.blockedHosts.flatMap(x => [x, `%.${x}`]) })
+			.andWhere(`following.followeeHost NOT IN (${ suspendedInstancesQuery.getQuery() })`)
+			.getRawOne()
+			.then(x => parseInt(x.count, 10));
+
+		const pub = await this.followingsRepository.createQueryBuilder('following')
+			.select('COUNT(DISTINCT following.followerHost)')
+			.where('following.followerHost IS NOT NULL')
+			.andWhere(this.meta.blockedHosts.length === 0 ? '1=1' : 'following.followerHost NOT ILIKE ALL(ARRAY[:...blocked])', { blocked: this.meta.blockedHosts.flatMap(x => [x, `%.${x}`]) })
+			.andWhere(`following.followerHost NOT IN (${ suspendedInstancesQuery.getQuery() })`)
+			.getRawOne()
+			.then(x => parseInt(x.count, 10));
+
+		const pubsub = await this.followingsRepository.createQueryBuilder('following')
+			.select('COUNT(DISTINCT following.followeeHost)')
+			.where('following.followeeHost IS NOT NULL')
+			.andWhere(this.meta.blockedHosts.length === 0 ? '1=1' : 'following.followeeHost NOT ILIKE ALL(ARRAY[:...blocked])', { blocked: this.meta.blockedHosts.flatMap(x => [x, `%.${x}`]) })
+			.andWhere(`following.followeeHost NOT IN (${ suspendedInstancesQuery.getQuery() })`)
+			.andWhere(`following.followeeHost IN (${ pubsubSubQuery.getQuery() })`)
+			.setParameters(pubsubSubQuery.getParameters())
+			.getRawOne()
+			.then(x => parseInt(x.count, 10));
+
+		const subActive = await this.instancesRepository.createQueryBuilder('instance')
+			.select('COUNT(instance.id)')
+			.where(`instance.host IN (${ subInstancesQuery.getQuery() })`)
+			.andWhere(this.meta.blockedHosts.length === 0 ? '1=1' : 'instance.host NOT ILIKE ALL(ARRAY[:...blocked])', { blocked: this.meta.blockedHosts.flatMap(x => [x, `%.${x}`]) })
+			.andWhere('instance.suspensionState = \'none\'')
+			.andWhere('instance.isNotResponding = false')
+			.getRawOne()
+			.then(x => parseInt(x.count, 10));
+
+		const pubActive = await this.instancesRepository.createQueryBuilder('instance')
+			.select('COUNT(instance.id)')
+			.where(`instance.host IN (${ pubInstancesQuery.getQuery() })`)
+			.andWhere(this.meta.blockedHosts.length === 0 ? '1=1' : 'instance.host NOT ILIKE ALL(ARRAY[:...blocked])', { blocked: this.meta.blockedHosts.flatMap(x => [x, `%.${x}`]) })
+			.andWhere('instance.suspensionState = \'none\'')
+			.andWhere('instance.isNotResponding = false')
+			.getRawOne()
+			.then(x => parseInt(x.count, 10));
 
 		return {
 			'sub': sub,

--- a/packages/backend/src/queue/processors/InboxProcessorService.ts
+++ b/packages/backend/src/queue/processors/InboxProcessorService.ts
@@ -37,6 +37,21 @@ type UpdateInstanceJob = {
 	shouldUnsuspend: boolean,
 };
 
+const JSON_LD_VALIDATION_ERROR_NAME = 'jsonld.ValidationError';
+const JSON_LD_VALIDATION_ERROR_MESSAGE = 'Safe mode validation error.';
+
+export function createUnrecoverableJsonLdError(error: unknown): Bull.UnrecoverableError | null {
+	if (error instanceof JsonLdError || (
+		error instanceof Error &&
+		error.name === JSON_LD_VALIDATION_ERROR_NAME &&
+		error.message === JSON_LD_VALIDATION_ERROR_MESSAGE
+	)) {
+		return new Bull.UnrecoverableError(`skip: encountered a JSON-LD error while verifying signature: ${error}`);
+	}
+
+	return null;
+}
+
 @Injectable()
 export class InboxProcessorService implements OnApplicationShutdown {
 	private logger: Logger;
@@ -193,11 +208,9 @@ export class InboxProcessorService implements OnApplicationShutdown {
 						throw new Bull.UnrecoverableError('skip: LD-Signatureの検証に失敗しました');
 					}
 				} catch (error) {
-					if (error instanceof JsonLdError) {
-						throw new Bull.UnrecoverableError(`skip: encountered a JSON-LD error while verifying signature: ${error}`);
-					} else {
-						throw error;
-					}
+					const unrecoverableError = createUnrecoverableJsonLdError(error);
+					if (unrecoverableError) throw unrecoverableError;
+					throw error;
 				}
 
 				// もう一度actorチェック

--- a/packages/backend/src/server/ActivityPubServerService.ts
+++ b/packages/backend/src/server/ActivityPubServerService.ts
@@ -31,7 +31,7 @@ import { IActivity } from '@/core/activitypub/type.js';
 import { isQuote, isRenote } from '@/misc/is-renote.js';
 import * as Acct from '@/misc/acct.js';
 import { FanoutTimelineEndpointService } from '@/core/FanoutTimelineEndpointService.js';
-import { FeaturedCollectionCacheService, type FeaturedCollection } from '@/core/FeaturedCollectionCacheService.js';
+import { FEATURED_COLLECTION_CACHE_TTL_SECONDS, FeaturedCollectionCacheService, type FeaturedCollection } from '@/core/FeaturedCollectionCacheService.js';
 import type { FastifyInstance, FastifyRequest, FastifyReply, FastifyPluginOptions, FastifyBodyParser } from 'fastify';
 import type { FindOptionsWhere } from 'typeorm';
 
@@ -427,7 +427,7 @@ export class ActivityPubServerService {
 			)) as FeaturedCollection;
 		});
 
-		reply.header('Cache-Control', 'public, max-age=180');
+		reply.header('Cache-Control', `public, max-age=${FEATURED_COLLECTION_CACHE_TTL_SECONDS}`);
 		vary(reply.raw, 'Accept');
 		this.setResponseType(request, reply);
 		return rendered;

--- a/packages/backend/src/server/ActivityPubServerService.ts
+++ b/packages/backend/src/server/ActivityPubServerService.ts
@@ -31,6 +31,7 @@ import { IActivity } from '@/core/activitypub/type.js';
 import { isQuote, isRenote } from '@/misc/is-renote.js';
 import * as Acct from '@/misc/acct.js';
 import { FanoutTimelineEndpointService } from '@/core/FanoutTimelineEndpointService.js';
+import { FeaturedCollectionCacheService, type FeaturedCollection } from '@/core/FeaturedCollectionCacheService.js';
 import type { FastifyInstance, FastifyRequest, FastifyReply, FastifyPluginOptions, FastifyBodyParser } from 'fastify';
 import type { FindOptionsWhere } from 'typeorm';
 
@@ -73,6 +74,7 @@ export class ActivityPubServerService {
 		private utilityService: UtilityService,
 		private userEntityService: UserEntityService,
 		private apRendererService: ApRendererService,
+		private featuredCollectionCacheService: FeaturedCollectionCacheService,
 		private queueService: QueueService,
 		private userKeypairService: UserKeypairService,
 		private queryService: QueryService,
@@ -402,28 +404,33 @@ export class ActivityPubServerService {
 			return;
 		}
 
-		const pinings = await this.userNotePiningsRepository.find({
-			where: { userId: user.id },
-			order: { id: 'DESC' },
+		const rendered = await this.featuredCollectionCacheService.fetch(user.id, async () => {
+			const pinings = await this.userNotePiningsRepository.createQueryBuilder('pin')
+				.innerJoinAndSelect('pin.note', 'note')
+				.where('pin.userId = :userId', { userId: user.id })
+				.andWhere('note.localOnly = FALSE')
+				.andWhere('note.visibility IN (:...visibilities)', { visibilities: ['public', 'home'] })
+				.orderBy('pin.id', 'DESC')
+				.getMany();
+
+			const pinnedNotes = pinings
+				.map(pining => pining.note)
+				.filter((note): note is NonNullable<typeof note> => note != null);
+			const renderedNotes = await Promise.all(pinnedNotes.map(note => this.apRendererService.renderNote(note)));
+
+			return this.apRendererService.addContext(this.apRendererService.renderOrderedCollection(
+				`${this.config.url}/users/${userId}/collections/featured`,
+				renderedNotes.length,
+				undefined,
+				undefined,
+				renderedNotes,
+			)) as FeaturedCollection;
 		});
 
-		const pinnedNotes = (await Promise.all(pinings.map(pining =>
-			this.notesRepository.findOneByOrFail({ id: pining.noteId }))))
-			.filter(note => !note.localOnly && ['public', 'home'].includes(note.visibility));
-
-		const renderedNotes = await Promise.all(pinnedNotes.map(note => this.apRendererService.renderNote(note)));
-
-		const rendered = this.apRendererService.renderOrderedCollection(
-			`${this.config.url}/users/${userId}/collections/featured`,
-			renderedNotes.length,
-			undefined,
-			undefined,
-			renderedNotes,
-		);
-
 		reply.header('Cache-Control', 'public, max-age=180');
+		vary(reply.raw, 'Accept');
 		this.setResponseType(request, reply);
-		return (this.apRendererService.addContext(rendered));
+		return rendered;
 	}
 
 	@bindThis

--- a/packages/backend/test/unit/FeaturedCollectionCacheService.ts
+++ b/packages/backend/test/unit/FeaturedCollectionCacheService.ts
@@ -1,0 +1,164 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, vi } from 'vitest';
+import * as Redis from 'ioredis';
+import { FeaturedCollectionCacheService, type FeaturedCollection } from '@/core/FeaturedCollectionCacheService.js';
+
+const collection: FeaturedCollection = {
+	'@context': {},
+	id: 'https://example.test/users/alice/collections/featured',
+	type: 'OrderedCollection',
+	totalItems: 0,
+};
+
+function createRedisMock() {
+	const values = new Map<string, string>();
+	const calls = {
+		eval: 0,
+		set: 0,
+	};
+	return {
+		client: {
+			get: async (key: string) => values.get(key) ?? null,
+			set: async (key: string, value: string, ...args: (string | number)[]) => {
+				calls.set++;
+				if (args.includes('NX') && values.has(key)) return null;
+				values.set(key, value);
+				return 'OK';
+			},
+			eval: async (script: string, _keyCount: number, ...args: string[]) => {
+				calls.eval++;
+				if (script.includes('redis.call(\'incr\'')) {
+					const [versionKey, cacheKey] = args;
+					values.set(versionKey, String(Number(values.get(versionKey) ?? '0') + 1));
+					return Number(values.delete(cacheKey));
+				}
+				if (script.includes('current = redis.call(\'get\'')) {
+					const [versionKey, cacheKey, version, value] = args;
+					const currentVersion = values.get(versionKey);
+					if ((currentVersion == null && version === '0') || currentVersion === version) {
+						values.set(cacheKey, value);
+						return 'OK';
+					}
+					return null;
+				}
+				if (script.includes('ARGV[1]')) {
+					const [lockKey, token] = args;
+					if (values.get(lockKey) === token) {
+						values.delete(lockKey);
+						return 1;
+					}
+				}
+				return 0;
+			},
+		} as unknown as Redis.Redis,
+		calls,
+		values,
+	};
+}
+
+describe('FeaturedCollectionCacheService', () => {
+	test('coalesces concurrent misses within a worker', async () => {
+		const { client, calls } = createRedisMock();
+		const service = new FeaturedCollectionCacheService(client);
+		const loader = vi.fn().mockResolvedValue(collection);
+
+		const [first, second] = await Promise.all([
+			service.fetch('alice', loader),
+			service.fetch('alice', loader),
+		]);
+
+		expect(first).toEqual(collection);
+		expect(second).toEqual(collection);
+		expect(loader).toHaveBeenCalledOnce();
+		expect(calls.eval).toBeGreaterThan(0);
+	});
+
+	test('reuses a collection populated in Redis', async () => {
+		const { client } = createRedisMock();
+		const service = new FeaturedCollectionCacheService(client);
+		const loader = vi.fn().mockResolvedValue(collection);
+
+		await service.fetch('alice', loader);
+		const cached = await service.fetch('alice', loader);
+
+		expect(cached).toEqual(collection);
+		expect(loader).toHaveBeenCalledOnce();
+	});
+
+	test('shares one render across backend workers with the Redis lock', async () => {
+		const { client, calls, values } = createRedisMock();
+		const firstService = new FeaturedCollectionCacheService(client);
+		const secondService = new FeaturedCollectionCacheService(client);
+		let resolveLoader: ((value: FeaturedCollection) => void) | undefined;
+		let markLoaderStarted: (() => void) | undefined;
+		const loaderStarted = new Promise<void>((resolve) => {
+			markLoaderStarted = resolve;
+		});
+		let firstLoaderCalls = 0;
+		const firstLoader = () => new Promise<FeaturedCollection>((resolve) => {
+			firstLoaderCalls++;
+			resolveLoader = resolve;
+			markLoaderStarted?.();
+		});
+		let secondLoaderCalls = 0;
+		const secondLoader = async () => {
+			secondLoaderCalls++;
+			return { ...collection, totalItems: 1 };
+		};
+
+		const first = firstService.fetch('alice', firstLoader);
+		await loaderStarted;
+		expect(firstLoaderCalls).toBe(1);
+		expect(calls.set).toBe(1);
+		expect(calls.eval).toBe(0);
+		expect([...values.keys()]).toContain('kvcache:activityPubFeatured:alice:lock');
+		const second = secondService.fetch('alice', secondLoader);
+		await new Promise<void>(resolve => setTimeout(resolve, 10));
+		expect(secondLoaderCalls).toBe(0);
+		if (resolveLoader == null) throw new Error('loader was not started');
+		resolveLoader(collection);
+
+		expect(await first).toEqual(collection);
+		expect(await second).toEqual(collection);
+		expect(secondLoaderCalls).toBe(0);
+	});
+
+	test('invalidates the shared collection after a pin change', async () => {
+		const { client, calls } = createRedisMock();
+		const service = new FeaturedCollectionCacheService(client);
+		const firstLoader = vi.fn().mockResolvedValue(collection);
+		const secondCollection = { ...collection, totalItems: 1 };
+		const secondLoader = vi.fn().mockResolvedValue(secondCollection);
+
+		await service.fetch('alice', firstLoader);
+		await service.invalidate('alice');
+		const refreshed = await service.fetch('alice', secondLoader);
+
+		expect(refreshed).toEqual(secondCollection);
+		expect(firstLoader).toHaveBeenCalledOnce();
+		expect(secondLoader).toHaveBeenCalledOnce();
+		expect(calls.eval).toBe(5);
+	});
+
+	test('does not repopulate Redis with a render started before invalidation', async () => {
+		const { client, calls } = createRedisMock();
+		const service = new FeaturedCollectionCacheService(client);
+		let resolveLoader: ((value: FeaturedCollection) => void) | undefined;
+		const loader = vi.fn(() => new Promise<FeaturedCollection>((resolve) => {
+			resolveLoader = resolve;
+		}));
+
+		const pending = service.fetch('alice', loader);
+		await vi.waitFor(() => expect(loader).toHaveBeenCalledOnce());
+		await service.invalidate('alice');
+		if (resolveLoader == null) throw new Error('loader was not started');
+		resolveLoader(collection);
+		await pending;
+
+		expect(calls.eval).toBe(2);
+	});
+});

--- a/packages/backend/test/unit/FeaturedCollectionCacheService.ts
+++ b/packages/backend/test/unit/FeaturedCollectionCacheService.ts
@@ -31,9 +31,9 @@ function createRedisMock() {
 			},
 			eval: async (script: string, _keyCount: number, ...args: string[]) => {
 				calls.eval++;
-				if (script.includes('redis.call(\'incr\'')) {
-					const [versionKey, cacheKey] = args;
-					values.set(versionKey, String(Number(values.get(versionKey) ?? '0') + 1));
+				if (script.includes('redis.call(\'set\', KEYS[1], ARGV[1], \'EX\'')) {
+					const [versionKey, cacheKey, version] = args;
+					values.set(versionKey, version);
 					return Number(values.delete(cacheKey));
 				}
 				if (script.includes('current = redis.call(\'get\'')) {
@@ -128,7 +128,7 @@ describe('FeaturedCollectionCacheService', () => {
 	});
 
 	test('invalidates the shared collection after a pin change', async () => {
-		const { client, calls } = createRedisMock();
+		const { client, calls, values } = createRedisMock();
 		const service = new FeaturedCollectionCacheService(client);
 		const firstLoader = vi.fn().mockResolvedValue(collection);
 		const secondCollection = { ...collection, totalItems: 1 };
@@ -136,12 +136,19 @@ describe('FeaturedCollectionCacheService', () => {
 
 		await service.fetch('alice', firstLoader);
 		await service.invalidate('alice');
+		const firstVersion = values.get('kvcache:activityPubFeatured:alice:version');
+		values.delete('kvcache:activityPubFeatured:alice:version');
+		await service.invalidate('alice');
+		const secondVersion = values.get('kvcache:activityPubFeatured:alice:version');
 		const refreshed = await service.fetch('alice', secondLoader);
 
 		expect(refreshed).toEqual(secondCollection);
+		expect(firstVersion).toBeDefined();
+		expect(secondVersion).toBeDefined();
+		expect(secondVersion).not.toBe(firstVersion);
 		expect(firstLoader).toHaveBeenCalledOnce();
 		expect(secondLoader).toHaveBeenCalledOnce();
-		expect(calls.eval).toBe(5);
+		expect(calls.eval).toBe(6);
 	});
 
 	test('does not repopulate Redis with a render started before invalidation', async () => {

--- a/packages/backend/test/unit/InboxProcessorService.ts
+++ b/packages/backend/test/unit/InboxProcessorService.ts
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import * as Bull from 'bullmq';
+import { describe, expect, test } from 'vitest';
+import { createUnrecoverableJsonLdError } from '@/queue/processors/InboxProcessorService.js';
+
+describe('InboxProcessorService JSON-LD error classification', () => {
+	test('does not retry deterministic jsonld validation errors', () => {
+		const error = Object.assign(new Error('Safe mode validation error.'), {
+			name: 'jsonld.ValidationError',
+		});
+
+		const unrecoverableError = createUnrecoverableJsonLdError(error);
+
+		expect(unrecoverableError).toBeInstanceOf(Bull.UnrecoverableError);
+	});
+
+	test('keeps transient errors retryable', () => {
+		const error = new Error('request timeout');
+
+		expect(createUnrecoverableJsonLdError(error)).toBeNull();
+	});
+
+	test('does not classify a different jsonld error as deterministic', () => {
+		const error = Object.assign(new Error('failed to load remote context'), {
+			name: 'jsonld.InvalidUrl',
+		});
+
+		expect(createUnrecoverableJsonLdError(error)).toBeNull();
+	});
+});

--- a/packages/backend/test/unit/InboxProcessorService.ts
+++ b/packages/backend/test/unit/InboxProcessorService.ts
@@ -5,9 +5,16 @@
 
 import * as Bull from 'bullmq';
 import { describe, expect, test } from 'vitest';
+import { JsonLdError } from '@/core/activitypub/JsonLdService.js';
 import { createUnrecoverableJsonLdError } from '@/queue/processors/InboxProcessorService.js';
 
 describe('InboxProcessorService JSON-LD error classification', () => {
+	test('does not retry JsonLdError instances', () => {
+		const error = new JsonLdError('test-jsonld-error', 'test');
+
+		expect(createUnrecoverableJsonLdError(error)).toBeInstanceOf(Bull.UnrecoverableError);
+	});
+
 	test('does not retry deterministic jsonld validation errors', () => {
 		const error = Object.assign(new Error('Safe mode validation error.'), {
 			name: 'jsonld.ValidationError',

--- a/packages/backend/test/unit/NoteDeleteService.ts
+++ b/packages/backend/test/unit/NoteDeleteService.ts
@@ -1,0 +1,71 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { describe, expect, test, vi } from 'vitest';
+import type { MiNote } from '@/models/Note.js';
+import { NoteDeleteService } from '@/core/NoteDeleteService.js';
+
+describe('NoteDeleteService', () => {
+	test('does not invalidate the featured collection when deleting an unpinned local note', async () => {
+		const notesRepository = {
+			delete: vi.fn().mockResolvedValue(undefined),
+		};
+		const userNotePiningsRepository = {
+			existsBy: vi.fn().mockResolvedValue(false),
+		};
+		const userEntityService = {
+			isLocalUser: vi.fn().mockReturnValue(true),
+		};
+		const searchService = {
+			unindexNote: vi.fn(),
+		};
+		const featuredCollectionCacheService = {
+			invalidate: vi.fn(),
+		};
+		const service = Reflect.construct(NoteDeleteService, [
+			{},
+			{},
+			{},
+			notesRepository,
+			{},
+			userNotePiningsRepository,
+			userEntityService,
+			{},
+			{},
+			{},
+			{},
+			{},
+			searchService,
+			{},
+			{},
+			{},
+			{},
+			featuredCollectionCacheService,
+		]) as NoteDeleteService;
+		const user = {
+			id: 'local-user',
+			uri: null,
+			host: null,
+			isBot: false,
+		};
+		const note = {
+			id: 'unpinned-note',
+			userId: user.id,
+			replyId: null,
+		} as MiNote;
+
+		await service.delete(user, note, true);
+
+		expect(userNotePiningsRepository.existsBy).toHaveBeenCalledWith({
+			userId: user.id,
+			noteId: note.id,
+		});
+		expect(featuredCollectionCacheService.invalidate).not.toHaveBeenCalled();
+		expect(notesRepository.delete).toHaveBeenCalledWith({
+			id: note.id,
+			userId: user.id,
+		});
+	});
+});


### PR DESCRIPTION
## What

- ActivityPub `featured` のnote取得をJOIN化し、180秒のRedis共有キャッシュとworker間single-flightを追加
- pin追加・解除、およびpin済みnoteの編集・削除時にキャッシュを無効化
- JSON-LD safe-mode validation errorを再試行不能として分類
- FederationChartの5本の集計SQLを並列実行から逐次実行へ変更

```mermaid
flowchart LR
    A["featured request"] --> B{"Redis cache"}
    B -->|"hit"| C["cached collection"]
    B -->|"miss"| D["distributed lock"]
    D --> E["JOIN query + render"]
    E --> F["180s cache"]
    G["pin / pinned note mutation"] --> H["versioned invalidation"]
    H --> B
```

## Why

PrisMisskeyで観測したCPU・DB負荷の集中、同一featured collectionの重複生成、決定的なJSON-LDエラーの無駄な再試行を抑えるためです。キャッシュはRedis障害時にもレスポンスを失敗させずDB生成へフォールバックし、remote user由来の不要なmetadataは作成しません。

## Additional info

- migration、entity、API schemaの変更はありません。
- FederationChartの集計semanticsは維持し、PostgreSQLからNodeへ全instance行を展開しません。
- focused Vitest: 8 tests passed
- backend source/test TypeScript: passed
- changed-file ESLint: passed

## Checklist

- [x] 新規TypeScriptファイルにSPDXヘッダーを追加
- [x] `CHANGELOG.md` のUnreleased / Serverを更新
- [x] focused unit testsを追加・実行
- [x] backend source/testの型検査を実行
- [x] 変更対象のESLintを実行
- [x] API生成・migration checkは対象外であることを確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * ActivityPubの「注目コレクション」をRedisの短寿命共有キャッシュで配信し、同時生成の抑制と表示負荷の軽減を行いました。ピン追加・解除・更新・削除に連動してキャッシュを適切に無効化します。
  * フェデレーション集計（グラフ）をクエリ逐次処理に見直し、負荷を抑えました。
  * JSON-LD検証の一部エラーを「再試行しない」扱いに分類し、不要なリトライを減らしました。
* **テスト**
  * 注目コレクション・Inboxエラー分類・注記削除の無効化動作に関するユニットテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->