### PR TITLE
fix: 非承認制チャンネルでもフォロワーを管理可能にする

### DIFF
--- a/packages/backend/test/e2e/channel-follow-approval.ts
+++ b/packages/backend/test/e2e/channel-follow-approval.ts
@@ -122,4 +122,29 @@ describe('チャンネルのフォロー承認', () => {
 		assert.strictEqual(approvalDisabledShow.body.hasPendingFollowRequest, false);
 		assert.strictEqual(approvalDisabledShow.body.followersCount, 2);
 	});
+
+	test('承認制ではないチャンネルでも既存フォロワーを管理できる', async () => {
+		const openChannel = await channel(owner, {
+			name: 'open-channel',
+			isFollowApprovalRequired: false,
+		});
+
+		const follow = await api('channels/follow', { channelId: openChannel.id }, follower);
+		assert.strictEqual(follow.status, 200);
+		assert.strictEqual(follow.body.state, 'following');
+
+		const openChannelFollowers = await api('channels/followers', { channelId: openChannel.id }, owner);
+		assert.strictEqual(openChannelFollowers.status, 200);
+		assert.strictEqual(openChannelFollowers.body.some(following => following.user.id === follower.id), true);
+
+		const removeFromOpenChannel = await api('channels/followers/remove', {
+			channelId: openChannel.id,
+			userId: follower.id,
+		}, owner);
+		assert.strictEqual(removeFromOpenChannel.status, 204);
+
+		const removedFromOpenChannelShow = await api('channels/show', { channelId: openChannel.id }, follower);
+		assert.strictEqual(removedFromOpenChannelShow.body.isFollowing, false);
+		assert.strictEqual(removedFromOpenChannelShow.body.followersCount, 0);
+	});
 });

--- a/packages/frontend/src/pages/channel.vue
+++ b/packages/frontend/src/pages/channel.vue
@@ -259,6 +259,9 @@ watch(() => props.channelId, async () => {
 	}
 
 	channel.value = _channel;
+	if (!headerTabs.value.some(headerTab => headerTab.key === tab.value)) {
+		tab.value = 'overview';
+	}
 	await refreshPendingFollowRequests();
 }, { immediate: true });
 
@@ -612,12 +615,12 @@ const headerTabs = computed(() => [{
 	key: 'events',
 	title: i18n.ts._events.eventCalendar,
 	icon: 'ti ti-calendar-event',
-}, ...(canManageChannelFollowers.value ? [{
+}, ...(canManageChannelFollowers.value && channel.value?.isFollowApprovalRequired ? [{
 		key: 'followRequests',
 		title: i18n.ts._channel.followRequests,
 		icon: 'ti ti-user-check',
 		indicate: hasPendingChannelFollowRequests.value,
-	}, {
+}] : []), ...(canManageChannelFollowers.value ? [{
 		key: 'followerManagement',
 		title: i18n.ts._channel.followerManagement,
 		icon: 'ti ti-users',


### PR DESCRIPTION
## What

- チャンネル管理者には、フォロー承認制の有無にかかわらず「フォロワー管理」タブを表示します。
- 「フォロー申請」タブは、フォロー承認制が有効なチャンネルだけに表示します。
- チャンネル切り替え後に選択中のタブが利用できない場合は、概要タブへ戻すようにしました。
- 承認制ではないチャンネルでも、既存フォロワーの一覧取得・削除・件数更新ができるE2Eテストを追加しました。

## Why

フォロー承認制ではない既存チャンネルでも、所有者や共同管理者が現在のフォロワーを整理できることを、UIとテストの両方で明確に保証するためです。

## Additional info (optional)

- APIやDBスキーマの変更はありません。既存の `channels/followers` と `channels/followers/remove` を利用します。
- `channel-follow-approval.ts` の対象E2Eは2件PASSしました。
- 対象VueのESLintとlocale safetyはPASSしました。
- frontend全体の型検査は、既存の `drop-and-fusion.game.vue` における `misskey-bubble-game` 解決エラーで失敗します。今回の変更箇所に型エラーは出ていません。
- SPDX全体検査は、`develop`に既存のマージ済みmigration 2件のヘッダー欠落によりFAILします。今回の差分にはSPDX対象の新規ファイルはありません。

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [x] (If needed) Add story of storybook
- [x] (If needed) Update CHANGELOG.md
- [x] (If possible) Add tests
